### PR TITLE
Revert "PLNSRVCE-1674: Migrate SprayProxy images to quay.io/konflux-ci"

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -14,7 +14,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/konflux-ci/sprayproxy/pull-request-builds:sprayproxy-{{revision}}"
+      value: "quay.io/redhat-appstudio/pull-request-builds:sprayproxy-{{revision}}"
   pipelineRef:
     params:
       - name: bundle

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -14,7 +14,7 @@ spec:
     - name: revision
       value: "{{revision}}"
     - name: output-image
-      value: "quay.io/konflux-ci/sprayproxy:{{revision}}"
+      value: "quay.io/redhat-appstudio/sprayproxy:{{revision}}"
     - name: infra-deployment-update-script
       value: |
         sed -i -E 's/[0-9a-f]{40}/{{ revision }}/g' components/sprayproxy/staging/kustomization.yaml


### PR DESCRIPTION
There is an issue pushing images to quay actually 
``` 
Error: POST https://quay.io/v2/redhat-appstudio/pull-request-builds/blobs/uploads/: UNAUTHORIZED: access to the requested resource is not authorized; map[]
main.go:74: error during command execution: POST https://quay.io/v2/redhat-appstudio/pull-request-builds/blobs/uploads/: UNAUTHORIZED: access to the requested resource is not authorized; map[]
```
We suspect the issue coming from  https://github.com/redhat-appstudio/infra-deployments/pull/3435
We trying to revert  https://github.com/redhat-appstudio/infra-deployments/pull/3435 here https://github.com/redhat-appstudio/infra-deployments/pull/3469

If the revert is merged we should also revert this 